### PR TITLE
use Open Sea standard for attributes

### DIFF
--- a/tips/TIP-0027/irc27.schema.json
+++ b/tips/TIP-0027/irc27.schema.json
@@ -51,8 +51,8 @@
       "description": "some information abou the NFT project"
     },
     "attributes": {
-      "type": "object",
-      "description": "object containing any additional arbitrary key-pairs"
+      "type": "array",
+      "description": "array containing any additional data as objects."
     }
   },
   "required": [ "standard", "type", "version", "nftId", "tokenUri" ]

--- a/tips/TIP-0027/tip-0027.md
+++ b/tips/TIP-0027/tip-0027.md
@@ -189,7 +189,9 @@ Optional, but recommended keys, that may be included in NFT schema include:
 
 In addition to the required and recommended schema, the inclusion of `attributes` allows for versatile expansion for NFT metadata.
 
-`attributes` are defined as a unique key and string that can be referenced in dApps to display metadata as required.
+`attributes` are the attributes for the item, which will show up on dApps like NFT Marketplaces.
+
+IRC27 NFT metadata follows the [OpenSea metadata standards](https://docs.opensea.io/docs/metadata-standards).
 
 ```json
 {
@@ -207,12 +209,24 @@ In addition to the required and recommended schema, the inclusion of `attributes
   },
   "issuerName": "My Artist Name",
   "description": "A little information about my NFT collection",
-  "attributes": {
-    "Background": "Purple",
-    "Element": "Water",
-    "Attack": "150",
-    "Health": "500"
-  }
+  "attributes": [
+    {
+      "trait_type": "Background",
+      "value": "Purple"
+    },
+    {
+      "trait_type": "Element",
+      "value": "Water"
+    },
+    {
+      "trait_type": "Attack",
+      "value": "150"
+    },
+    {
+      "trait_type": "Health",
+      "value": "500"
+    },
+  ]
 }
 ```
 


### PR DESCRIPTION
The attribute field was a bit different to the current standards - here is a proposal to TIP27 to be compatible with this standard.

OpenSea supports metadata that is structured according to [the official ERC721 metadata standard](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md) or the [Enjin Metadata suggestions](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1155.md#erc-1155-metadata-uri-json-schema).


Changes: 

- `attributes` field is now an array with objects. 
- Change example